### PR TITLE
fix timezone warning. Add timezone information to fixtures and check if datetimes are equal in tests

### DIFF
--- a/lmn/fixtures/testing_notes.json
+++ b/lmn/fixtures/testing_notes.json
@@ -1,29 +1,35 @@
 [
-    {"model" : "lmn.note", "pk" : 1 , "fields" :
-      { "show" : "1",
-        "user" : "1",
-        "title" : "ok",
-        "text" : "kinda ok",
-        "posted_date" : "2017-02-12"
-      }
-    },
-
-    {"model" : "lmn.note", "pk" : 2 , "fields" :
-      { "show" : "1",
-        "user" : "2",
-        "title" : "awesome",
-        "text" : "yay!",
-        "posted_date" : "2017-02-13"
-      }
-    },
-
-    {"model" : "lmn.note", "pk" : 3 , "fields" :
-      { "show" : "2",
-        "user" : "2",
-        "title" : "super",
-        "text" : "woo hoo!",
-        "posted_date" : "2017-02-14"
-      }
+  {
+    "model":"lmn.note",
+    "pk":1,
+    "fields":{
+      "show":"1",
+      "user":"1",
+      "title":"ok",
+      "text":"kinda ok",
+      "posted_date":"2018-02-12T21:45:00-06:00"
     }
-
+  },
+  {
+    "model":"lmn.note",
+    "pk":2,
+    "fields":{
+      "show":"1",
+      "user":"2",
+      "title":"awesome",
+      "text":"yay!",
+      "posted_date":"2018-02-13T09:45:00-06:00"
+    }
+  },
+  {
+    "model":"lmn.note",
+    "pk":3,
+    "fields":{
+      "show":"2",
+      "user":"2",
+      "title":"super",
+      "text":"woo hoo!",
+      "posted_date":"2018-02-14T14:15:00-06:00"
+    }
+  }
 ]

--- a/lmn/fixtures/testing_shows.json
+++ b/lmn/fixtures/testing_shows.json
@@ -1,20 +1,29 @@
 [
-  {"model" : "lmn.show", "pk" : 1 , "fields" :
-    { "show_date" : "2017-01-02",
-      "artist" : 1,
-      "venue" : 2
+  {
+    "model": "lmn.show",
+    "pk": 1,
+    "fields":{
+      "show_date": "2017-01-02T17:30:00-00:00",
+      "artist":1,
+      "venue":2
     }
   },
-  {"model" : "lmn.show", "pk" : 2 , "fields" :
-    { "show_date" : "2017-02-02",
-      "artist" : 1,
-      "venue" : 2
+  {
+    "model": "lmn.show",
+    "pk":2,
+    "fields":{
+      "show_date": "2017-02-02T19:30:00-00:00",
+      "artist":1,
+      "venue":2
     }
   },
-  {"model" : "lmn.show", "pk" : 3 , "fields" :
-    { "show_date" : "2017-01-21",
-      "artist" : 2,
-      "venue" : 1
+  {
+    "model": "lmn.show",
+    "pk":3,
+    "fields":{
+      "show_date": "2017-01-21T21:45:00-00:00",
+      "artist":2,
+      "venue":1
     }
   }
 ]

--- a/lmn/tests/test_views.py
+++ b/lmn/tests/test_views.py
@@ -134,26 +134,29 @@ class TestArtistViews(TestCase):
         self.assertEqual(show1.artist.name, 'REM')
         self.assertEqual(show1.venue.name, 'The Turf Club')
 
-        expected_date = datetime.datetime(2017, 2, 2, 0, 0, tzinfo=timezone.utc)
-        self.assertEqual(0, (show1.show_date - expected_date).total_seconds())
+        # From the fixture, show 2's "show_date": "2017-02-02T19:30:00-06:00"
+        expected_date = datetime.datetime(2017, 2, 2, 19, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(show1.show_date, expected_date)
 
+        # from the fixture, show 1's "show_date": "2017-01-02T17:30:00-00:00",
         self.assertEqual(show2.artist.name, 'REM')
         self.assertEqual(show2.venue.name, 'The Turf Club')
-        expected_date = datetime.datetime(2017, 1, 2, 0, 0, tzinfo=timezone.utc)
-        self.assertEqual(0, (show2.show_date - expected_date).total_seconds())
+        expected_date = datetime.datetime(2017, 1, 2, 17, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(show2.show_date, expected_date)
 
         # Artist 2 (ACDC) has played at venue 1 (First Ave)
 
-        url = reverse('venues_for_artist', kwargs={'artist_pk':2})
+        url = reverse('venues_for_artist', kwargs={'artist_pk': 2})
         response = self.client.get(url)
         shows = list(response.context['shows'].all())
         show1 = shows[0]
         self.assertEqual(1, len(shows))
 
+        # This show has "show_date": "2017-01-21T21:45:00-00:00",
         self.assertEqual(show1.artist.name, 'ACDC')
         self.assertEqual(show1.venue.name, 'First Avenue')
-        expected_date = datetime.datetime(2017, 1, 21, 0, 0, tzinfo=timezone.utc)
-        self.assertEqual(0, (show1.show_date - expected_date).total_seconds())
+        expected_date = datetime.datetime(2017, 1, 21, 21, 45, 0, tzinfo=timezone.utc)
+        self.assertEqual(show1.show_date, expected_date)
 
         # Artist 3 , no shows
 
@@ -253,27 +256,30 @@ class TestVenues(TestCase):
             self.assertEqual(show1.artist.name, 'REM')
             self.assertEqual(show1.venue.name, 'The Turf Club')
 
-            expected_date = datetime.datetime(2017, 2, 2, 0, 0, tzinfo=timezone.utc)
-            self.assertEqual(0, (show1.show_date - expected_date).total_seconds())
+            # From the fixture, show 2's "show_date": "2017-02-02T19:30:00-06:00"
+            expected_date = datetime.datetime(2017, 2, 2, 19, 30, 0, tzinfo=timezone.utc)
+            self.assertEqual(show1.show_date, expected_date)
 
+            # from the fixture, show 1's "show_date": "2017-01-02T17:30:00-00:00",
             self.assertEqual(show2.artist.name, 'REM')
             self.assertEqual(show2.venue.name, 'The Turf Club')
-            expected_date = datetime.datetime(2017, 1, 2, 0, 0, tzinfo=timezone.utc)
-            self.assertEqual(0, (show2.show_date - expected_date).total_seconds())
+            expected_date = datetime.datetime(2017, 1, 2, 17, 30, 0, tzinfo=timezone.utc)
+            self.assertEqual(show2.show_date, expected_date)
 
             # Artist 2 (ACDC) has played at venue 1 (First Ave)
 
-            url = reverse('artists_at_venue', kwargs={'venue_pk':1})
+            url = reverse('venues_for_artist', kwargs={'artist_pk': 2})
             response = self.client.get(url)
             shows = list(response.context['shows'].all())
             show1 = shows[0]
             self.assertEqual(1, len(shows))
 
+            # This show has "show_date": "2017-01-21T21:45:00-00:00",
             self.assertEqual(show1.artist.name, 'ACDC')
             self.assertEqual(show1.venue.name, 'First Avenue')
-            expected_date = datetime.datetime(2017, 1, 21, 0, 0, tzinfo=timezone.utc)
-            self.assertEqual(0, (show1.show_date - expected_date).total_seconds())
-
+            expected_date = datetime.datetime(2017, 1, 21, 21, 45, 0, tzinfo=timezone.utc)
+            self.assertEqual(show1.show_date, expected_date)
+            
             # Venue 3 has not had any shows
 
             url = reverse('artists_at_venue', kwargs={'venue_pk':3})


### PR DESCRIPTION
Fixes these warnings x6 when tests run 
```
init__.py:1367: RuntimeWarning: DateTimeField Note.posted_date received a naive datetime (2017-02-12 00:00:00) while time zone support is active.
```

Tidied fixture file, included the timezone as well as the date. The warning above is issued when each object in a fixture without a  timezone is added to the database.

Cleaner checks in test for timezone, directly comparing datetimes.

